### PR TITLE
fix: update title of @iteam/hooks

### DIFF
--- a/hooks/available-hooks.md
+++ b/hooks/available-hooks.md
@@ -1,4 +1,4 @@
-## [useToggle](#useToggle)
+## useToggle
 
 Uses `useState` but returns a setter function that toggles the value.
 
@@ -9,17 +9,17 @@ useToggle(initialValue: boolean): [boolean, () => void]
 ### Example
 
 ```js
-import React from "react";
-import { useToggle } from "@iteam/hooks";
+import React from 'react'
+import { useToggle } from '@iteam/hooks'
 
 export const ToggleComponent = () => {
-  const [isAlive, toggleValue] = useToggle(false);
+  const [isAlive, toggleValue] = useToggle(false)
 
-  return <button onClick={toggleValue}>{isAlive ? "🚀" : "😴"}</button>;
-};
+  return <button onClick={toggleValue}>{isAlive ? '🚀' : '😴'}</button>
+}
 ```
 
-## [useQueryParams](#useQueryParams)
+## useQueryParams
 
 Gets all the query param values
 
@@ -32,20 +32,20 @@ useQueryParams(): { [key: string]: string | string[] | undefined }
 ```js
 // https://awesome.domain/?name=cookie&lastName=monster
 
-import React from "react";
-import { useQueryParams } from "@iteam/hooks";
+import React from 'react'
+import { useQueryParams } from '@iteam/hooks'
 
 export const NeedsABunchOfParams = () => {
-  const params = useQueryParams();
+  const params = useQueryParams()
 
-  console.log(params);
+  console.log(params)
   // { name: 'cookie', lastName: 'monster' }
 
-  return null;
-};
+  return null
+}
 ```
 
-## [useQueryParam](#useQueryParam)
+## useQueryParam
 
 Gets a value from a specified query param, useful if you only require one value
 out of a bunch. Uses `useQueryParams` under the hood.
@@ -57,23 +57,23 @@ useQueryParam(param: string): string | string[]
 ### Example
 
 ```js
-import React from "react";
-import { useQueryParam } from "@iteam/hooks";
+import React from 'react'
+import { useQueryParam } from '@iteam/hooks'
 
 export const NeedsAParam = () => {
-  const param = useQueryParam("sweetParam");
+  const param = useQueryParam('sweetParam')
 
   return (
     <div>
-      {typeof param === "string"
+      {typeof param === 'string'
         ? `That's a nice query param with the value ${param}`
-        : `Woah! A bunch of params ${param.join(",")}`}
+        : `Woah! A bunch of params ${param.join(',')}`}
     </div>
-  );
-};
+  )
+}
 ```
 
-## [useDebounce](#useDebounce)
+## useDebounce
 
 Debounce the updating of a value
 
@@ -84,16 +84,16 @@ useDebounce<ValueType>(value: ValueType, duration: number): ValueType
 ### Example
 
 ```js
-import React from "react";
-import { useDebounce } from "@iteam/hooks";
+import React from 'react'
+import { useDebounce } from '@iteam/hooks'
 
 export const Debounced = () => {
-  const [inputValue, setInputValue] = React.useState("");
-  const debouncedValue = useDebounce(inputValue, 300);
+  const [inputValue, setInputValue] = React.useState('')
+  const debouncedValue = useDebounce(inputValue, 300)
 
-  const handleChange = e => {
-    setInputValue(e.currentTarget.value);
-  };
+  const handleChange = (e) => {
+    setInputValue(e.currentTarget.value)
+  }
 
   return (
     <div>
@@ -101,11 +101,11 @@ export const Debounced = () => {
       <input id="test-input" onChange={handleChange} value={debouncedValue} />
       {debouncedValue}
     </div>
-  );
-};
+  )
+}
 ```
 
-## [useLocalStorage](#useLocalStorage)
+## useLocalStorage
 
 Get and set values in `localStorage`. Uses `useStorage` under the hood.
 
@@ -116,28 +116,28 @@ useLocalStorage(key: string, initialValue?: any): [string, (newValue: string) =>
 ### Example
 
 ```js
-import React from "react";
-import { useLocalStorage } from "@iteam/hooks";
+import React from 'react'
+import { useLocalStorage } from '@iteam/hooks'
 
 export const Storage = ({ initialValue }) => {
-  const [value, setValue] = useLocalStorage("storedValue", initialValue);
+  const [value, setValue] = useLocalStorage('storedValue', initialValue)
 
   return (
     <div>
-      {value ? value : "no value ;("}
+      {value ? value : 'no value ;('}
       <label htmlFor="store">Update store value</label>
       <input
         id="store"
-        onChange={e => setValue(e.currentTarget.value)}
+        onChange={(e) => setValue(e.currentTarget.value)}
         type="text"
         value={value}
       />
     </div>
-  );
-};
+  )
+}
 ```
 
-## [useStorage](#useStorage)
+## useStorage
 
 Get and set values in any store with a `getItem` or `setItem`. Defaults to
 `localStorage`. Useful if you want to add something to for example `sessionStorage`.
@@ -149,26 +149,26 @@ useStorage(key: string, options?: { initialValue?: any, store?: Storage }): [str
 ### Example
 
 ```js
-import React from "react";
-import { useStorage } from "@iteam/hooks";
+import React from 'react'
+import { useStorage } from '@iteam/hooks'
 
 export const Storage = ({ initialValue }) => {
-  const [value, setValue] = useStorage("storedValue", {
+  const [value, setValue] = useStorage('storedValue', {
     initialValue,
-    store: sessionStorage
-  });
+    store: sessionStorage,
+  })
 
   return (
     <div>
-      {value ? value : "no value ;("}
+      {value ? value : 'no value ;('}
       <label htmlFor="store">Update store value</label>
       <input
         id="store"
-        onChange={e => setValue(e.currentTarget.value)}
+        onChange={(e) => setValue(e.currentTarget.value)}
         type="text"
         value={value}
       />
     </div>
-  );
-};
+  )
+}
 ```


### PR DESCRIPTION
This PR fixes the sidebar links for `@iteam/hooks`. This happened because the titles, which had been copied from the [readme](https://github.com/Iteam1337/hooks#readme), were linked. Prettier also kicked in and formatted the code examples.

| Before | After |
| ------ | ----- |
| ![Screenshot 2020-08-26 at 15 24 15](https://user-images.githubusercontent.com/1478102/91309098-7b78dc00-e7b0-11ea-9818-1a69d38c1632.png) | ![Screenshot 2020-08-26 at 15 24 11](https://user-images.githubusercontent.com/1478102/91309094-7a47af00-e7b0-11ea-99f8-7fcca6448148.png) |

